### PR TITLE
Finished initial middleware (`Seeder`) traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,18 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "autocfg"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,55 +45,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "futures-channel"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
-
-[[package]]
-name = "futures-task"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-util"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
-dependencies = [
- "futures-core",
- "futures-task",
- "pin-project-lite",
- "pin-utils",
-]
 
 [[package]]
 name = "gimli"
@@ -123,31 +66,6 @@ dependencies = [
  "serde_json",
  "tokio",
 ]
-
-[[package]]
-name = "h2"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "http"
@@ -177,22 +95,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
- "futures-channel",
- "futures-util",
- "h2",
  "http",
  "http-body",
  "tokio",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
-dependencies = [
- "equivalent",
- "hashbrown",
 ]
 
 [[package]]
@@ -249,22 +154,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
@@ -341,15 +234,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "slab"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "socket2"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,38 +299,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tracing"
-version = "0.1.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
-dependencies = [
- "pin-project-lite",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
-dependencies = [
- "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.6.0"
 optional = true
 
 [features]
-http2 = ["hyper/http2"]
+#http2 = ["hyper/http2"]
 serde = ["dep:serde"]
 serde_all = ["serde", "serde_json", "serde_xml"]
 serde_json = ["serde", "dep:serde_json"]


### PR DESCRIPTION
Creation of various traits for use in middleware creation

# `Unpacker` trait
An `Unpacker` is an object which reads a byte stream from a TCP socket and transforms it into
an HttpRequest object. The body of an `Unpacker` is only passed along as a series of
heap-allocated bytes, the `Unpacker` does not parse the request body, it only packages it into a
`BoxBody` to be passed between different middlewares.

A `Seeder` is an object which transforms this data. Many `Seeder`s can exist before a `Router`
is hit. A `Seeder` can also be used within a `Router`. `Seeder`s can also be used as Route
guards, preventing access to a `Route`/`Router` unless the `Seeder` has verified a set of
criteria.

Management of all transformed data is handled within the `<dyn Router>` handler. The `Router`
is responsible for matching the HttpRequest against a series of internal routes, and providing
the HttpRequest to the correct route.

# `Guard` enum
Holds the accessibility state of a route, as handled by a `Seeder` acting as a route guard
any series of `Route`s/`Router`s.

`Guard::Accessible(&HttpRequest<BoxBody>)` is used to pass along a successful route check to
the `HttpServer`. This makes allows the request to access the requested resource.

`Guard::Inaccessible { reason, status_code }` is used to pass along a route check that was
unsuccessful, containing the request body, reason, and status code to use for the rejected
request. A `Seeder` can be used to catch `Inaccessible` requests and create a new response body.
This can be used for things like providing error codes, error traces, messages, standardized
API responses, and more.

# `Respondent` enum
Contains a `Respondent` for a `Guard::Inaccessible` result from a `Seeder` object.

This enum holds the required action for the next `Seeder` which is handling the result from the
`Seeder` which returned the `Guard::Inaccessible` result.

# `BoxBody` struct
An object representing some heap-allocated HTTP request's body.

This internally holds an atomically reference-counted pointer to the data,
allowing for packing/unpacking the data into a desired data type. This also allows for multiple
accessors to the inner data.

By default, the requested data type must implement `TryFrom<&[u8]>`, which makes conversion
to/from a string easy, however on other data types this might be more involved.

# `SeederFactory` trait
Trait implemented on an object which may create any `Seeder` object.

`SeederFactory` objects generally don't maintain instances of themselves, they should be a
static, sized struct whose sole purpose is instantiating `Seeder` objects.

The purpose of the `SeederFactory` is to allow for a `Seeder` to be re-instantiated by other
`Seeder`s during the request chain, during operations which may require reprocessing of an
`HttpRequest`.

# `Seeder` trait
Trait implemented on an object which implements some middleware functionality.

Structs which implement `Seeder` can be constructed and passed to the HTTP server to check
or update the parameters of an HTTP request.